### PR TITLE
Get rental total with lease

### DIFF
--- a/dataset.csv
+++ b/dataset.csv
@@ -1,0 +1,43 @@
+Property Name,Property Address [1],Property  Address [2],Property Address [3],Property Address [4],Unit Name,Tenant Name,Lease Start Date,Lease End Date,Lease Years,Current Rent
+Beecroft Hill,Broad Lane,,,LS13,Beecroft Hill - Telecom App,Arqiva Services ltd,01 Mar 1994,28 Feb 2058,64,23950.00
+Potternewton Crescent,Potternewton Est Playing Field,,,LS7,Potternewton Est Playing Field,Arqiva Ltd,24 Jun 1999,23 Jun 2019,20,6600.00
+Seacroft Gate (Chase) - Block 2,Telecomms Apparatus,Leeds,,LS14,Seacroft Gate (Chase) block 2-Telecom App.,Vodafone Ltd.,30 Jan 2004,29 Jan 2029,25,12250.00
+Queenswood Heights,Queenswood Heights,Queenswood Gardens,Headingley,Leeds,Queenswood Hgt-Telecom App.,Vodafone Ltd,08 Nov 2004,07 Nov 2029,25,9500.00
+Armley - Burnsall Grange,Armley,LS13,,,Burnsall Grange CSR 37865,O2 (UK) Ltd,26 Jul 2007,25 Jul 2032,25,12000.00
+Seacroft Gate (Chase) - Block 2,Telecomms Apparatus,Leeds,,LS14,"Seacroft Gate (Chase) - Block 2, WYK 0414",Hutchinson3G Uk Ltd&Everything Everywhere Ltd,21 Aug 2007,20 Aug 2032,25,12750.00
+Cottingley Towers,Leeds,,,LS11,Cottingley Towers-WYK0052,Everything Everywhere Ltd,28 Jan 2008,27 Jan 2018,10,12750.00
+Potternewton Heights - Tel App,Potternewton Heights,Potternewton Lne,Leeds,,Potternewton Heights,Everything Everywhere Ltd,04 Mar 2008,03 Mar 2018,10,12750.00
+Gipton Gate West,Leeds,,,LS9,Gipton Gate West-WYK0021,Everything Everywhere Ltd & Hutchinson 3G UK,01 Apr 2008,31 Mar 2018,10,12750.00
+Theaker Lane,Burnsall Grange,Leeds,,LS12,Burnsall Grange - WYK0144,Everything Everywhere Ltd,29 Apr 2008,28 Apr 2018,10,12750.00
+Gledhow Towers - Telecom App,Brackenwood Drive,Leeds,,,Gledhow Towers - WYK0188,Everything Everywhere Ltd & Hutchinson 3G UK,20 May 2008,19 May 2018,10,12750.00
+Lovell Park Heights,Yeb,,,LS7,Lovell Park Heights-- WYK0207,Everything Everywhere Ltd,17 Jun 2008,16 Jun 2018,10,12750.00
+Shakespeare Towers,,,,LS9,Shakespeare Towers ref 1704255985,EverythingEverywhere Ltd & Hutchinson3GUK Ltd,10 Jun 2009,09 Jun 2019,10,12750.00
+Grayson Heights,Eden Mount,Burley Park,Leeds,LS5,Grayson Heights LDS175   LS0029,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+Oatland Towers,Little London,,Leeds,,Oatland Towers LDS133   99603,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,15296.63
+The Heights East,Gamble Hill,Bramley,Leeds 12,,The Heights East LDS045   55032,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+The Heights,Farrow Bank Gamble Hill,Leeds,,,Raynville Court LDS047   55035,Everything Everywhere Ltd&Hutchison 3G UK LTd,01 Aug 2009,31 Jul 2019,10,14730.08
+Barncroft Towers,Seacroft,Yeb Ref 10462,,LS14,Barncroft Towers - Site Ref LDS138   99632,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+Queens View,Seacroft,,,LS14,Queens View LDS232   LS0098,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,28327.09
+Parkway Grange,Foundry Lane,Leeds,,LS14,Parkway Grange - Site Ref LDS134   99604,Everything Everywhere Ltd&Hutchsion 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+Seacroft Gate Block 1,Eastdean,Leeds,,,Seacroft Gate Block 1 LDS032   55007,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+Cartmell Drive,Halton Moor,Leeds,,LS15,Lakeland Court Flats Cell LDS142   99925,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+Norman Towers (Telecom Appar),Spen Lane,Leeds,,LS16,Norman Towers LDS132 (Telecom Appar)   99448,Everything Everywhere Ltd&Hutchsion 3G Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+Clayton Court,Fillingfir Drive,,Leeds,LS18,Clayton Court LDS198   LS0056,Everything Everywhere Ltd & Hutchison 3G Ltd,01 Aug 2009,31 Jul 2019,10,15296.63
+Meynell Heights,,,,LS11,Meynell Heights- Wyk0184,Everything Everywhere Ltd & Hutchinson 3G UK,03 Aug 2009,02 Aug 2019,10,12750.00
+Larkhill Road,Lidgett Towers,Larkhill Road,Leeds,,Lidgett Towers - Site ref 27874,Everything Everywhere Ltd&Hutchison 3G UK Ltd,05 Jul 2010,04 Jul 2020,10,13000.00
+Marlborough Towers,Marlborough Towers,Park Lane,Leeds,,Marlborough Towers-Telecom App 7942vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Queenswood Drive - Telecom Site,Headingley,Leeds,LS6,,Queenswood Drive-Q'wood Ct building 19089o2,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Clayton Court,Fillingfir,,Leeds,,Clayton Court 11279vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Gledhow Towers - Telecom App,Brackenwood Drive,Leeds,,,Gledhow Towers - Telecom App (34909vf),Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Larkhill Road,Lidgett Towers,Larkhill Road,Leeds,,Lidgett Towers - Telecom App 3420vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Gipton Gate East,Oaktree Drive,,,,Gipton Gate East 23201vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+The Heights East,Armley,Leeds,,LS12,The Heights East- 4797o2,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Burnsall Gardens,Theaker Lane,,,,Burnsall Gardens - Cell No 23144vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,17000.00
+Poplar Mount,Armley,,,LS13,Poplar Mount Telecom Site 34884vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Barncroft Court,Seacroft,Yeb Ref 10463,,LS14,Barncroft Court 34196o2,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Barncroft Grange,Boggart Hill Drive,Seacroft,Leeds,LS14,Barncroft Grange Site 10639vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,17000.00
+Bailey Lane,Baileys Lane,Leeds,,,"Baileys Towers, Bailey Lane Ref 33420o2",Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Sherburn Court,Mill Green,,Leeds,,Sherburn Court CSR 16878o2,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Cartmell Drive,Halton Moor,Leeds,,LS15,Lakeland Court Cell No 35649o2,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Norman Towers (Telecom Appar),Spen Lane,Leeds,,LS16,Norman Towers (Telecom Appar) 1701o2,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,22500.00
+King Lane,Leafield Towers,Leeds,,LS16,Leafield Towers - Cell 5516vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00

--- a/main.py
+++ b/main.py
@@ -1,0 +1,13 @@
+import csv
+
+
+from modules.getRentalTotalWithLease import getRentalTotalWithLease
+
+if __name__ == '__main__':
+    with open('dataset.csv', 'r', newline="") as csvfile:
+        reader = list(csv.DictReader(csvfile))
+
+    if reader is not None:
+        print("Enter Lease number to get rental total for it: ")
+        lease = input()
+        print("Rental total for lease of {lease}: ".format(lease=lease) + str(getRentalTotalWithLease(reader, int(lease))))

--- a/modules/getRentalTotalWithLease.py
+++ b/modules/getRentalTotalWithLease.py
@@ -1,0 +1,20 @@
+def getRentalTotalWithLease(reader, years):
+    """
+
+    years: select the specific number of Lease Years to add rental together.
+
+    """
+    if isinstance(years, int) is False:
+        raise TypeError("Expecting Integer type value")
+
+    # list comprehension to get all data with specified years
+    listCompres = [row for row in reader if row["Lease Years"] == str(years)]
+    totalRental = 0
+    if len(listCompres) > 0:
+        for currRent in listCompres:
+            totalRental += float(currRent["Current Rent"])
+            print(currRent)
+    else:
+        raise ValueError("Specified Year does not exist")
+
+    return totalRental

--- a/modules/test_getRentalTotalWithLease.py
+++ b/modules/test_getRentalTotalWithLease.py
@@ -1,0 +1,28 @@
+import unittest
+import csv
+from getRentalTotalWithLease import getRentalTotalWithLease
+
+
+class TestGetRentalTotalWithLease(unittest.TestCase):
+
+    def setUp(self):
+        print("\ntestSetup")
+        with open('testDataset.csv', 'r', newline="") as csvfile:
+            self.reader = list(csv.DictReader(csvfile))
+
+    def test_getRentalTotalWithLease(self):
+        print("\ntestingFunc")
+
+        totalRental = getRentalTotalWithLease(self.reader, 25)
+        self.assertEqual(totalRental, 46500)
+        totalRental = getRentalTotalWithLease(self.reader, 64)
+        self.assertEqual(totalRental, 23950)
+
+        with self.assertRaises(ValueError):
+            getRentalTotalWithLease(self.reader, 73)
+        with self.assertRaises(TypeError):
+            getRentalTotalWithLease(self.reader, '73')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/testDataset.csv
+++ b/testDataset.csv
@@ -1,0 +1,43 @@
+Property Name,Property Address [1],Property  Address [2],Property Address [3],Property Address [4],Unit Name,Tenant Name,Lease Start Date,Lease End Date,Lease Years,Current Rent
+Beecroft Hill,Broad Lane,,,LS13,Beecroft Hill - Telecom App,Arqiva Services ltd,01 Mar 1994,28 Feb 2058,64,23950.00
+Potternewton Crescent,Potternewton Est Playing Field,,,LS7,Potternewton Est Playing Field,Arqiva Ltd,24 Jun 1999,23 Jun 2019,20,6600.00
+Seacroft Gate (Chase) - Block 2,Telecomms Apparatus,Leeds,,LS14,Seacroft Gate (Chase) block 2-Telecom App.,Vodafone Ltd.,30 Jan 2004,29 Jan 2029,25,12250.00
+Queenswood Heights,Queenswood Heights,Queenswood Gardens,Headingley,Leeds,Queenswood Hgt-Telecom App.,Vodafone Ltd,08 Nov 2004,07 Nov 2029,25,9500.00
+Armley - Burnsall Grange,Armley,LS13,,,Burnsall Grange CSR 37865,O2 (UK) Ltd,26 Jul 2007,25 Jul 2032,25,12000.00
+Seacroft Gate (Chase) - Block 2,Telecomms Apparatus,Leeds,,LS14,"Seacroft Gate (Chase) - Block 2, WYK 0414",Hutchinson3G Uk Ltd&Everything Everywhere Ltd,21 Aug 2007,20 Aug 2032,25,12750.00
+Cottingley Towers,Leeds,,,LS11,Cottingley Towers-WYK0052,Everything Everywhere Ltd,28 Jan 2008,27 Jan 2018,10,12750.00
+Potternewton Heights - Tel App,Potternewton Heights,Potternewton Lne,Leeds,,Potternewton Heights,Everything Everywhere Ltd,04 Mar 2008,03 Mar 2018,10,12750.00
+Gipton Gate West,Leeds,,,LS9,Gipton Gate West-WYK0021,Everything Everywhere Ltd & Hutchinson 3G UK,01 Apr 2008,31 Mar 2018,10,12750.00
+Theaker Lane,Burnsall Grange,Leeds,,LS12,Burnsall Grange - WYK0144,Everything Everywhere Ltd,29 Apr 2008,28 Apr 2018,10,12750.00
+Gledhow Towers - Telecom App,Brackenwood Drive,Leeds,,,Gledhow Towers - WYK0188,Everything Everywhere Ltd & Hutchinson 3G UK,20 May 2008,19 May 2018,10,12750.00
+Lovell Park Heights,Yeb,,,LS7,Lovell Park Heights-- WYK0207,Everything Everywhere Ltd,17 Jun 2008,16 Jun 2018,10,12750.00
+Shakespeare Towers,,,,LS9,Shakespeare Towers ref 1704255985,EverythingEverywhere Ltd & Hutchinson3GUK Ltd,10 Jun 2009,09 Jun 2019,10,12750.00
+Grayson Heights,Eden Mount,Burley Park,Leeds,LS5,Grayson Heights LDS175   LS0029,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+Oatland Towers,Little London,,Leeds,,Oatland Towers LDS133   99603,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,15296.63
+The Heights East,Gamble Hill,Bramley,Leeds 12,,The Heights East LDS045   55032,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+The Heights,Farrow Bank Gamble Hill,Leeds,,,Raynville Court LDS047   55035,Everything Everywhere Ltd&Hutchison 3G UK LTd,01 Aug 2009,31 Jul 2019,10,14730.08
+Barncroft Towers,Seacroft,Yeb Ref 10462,,LS14,Barncroft Towers - Site Ref LDS138   99632,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+Queens View,Seacroft,,,LS14,Queens View LDS232   LS0098,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,28327.09
+Parkway Grange,Foundry Lane,Leeds,,LS14,Parkway Grange - Site Ref LDS134   99604,Everything Everywhere Ltd&Hutchsion 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+Seacroft Gate Block 1,Eastdean,Leeds,,,Seacroft Gate Block 1 LDS032   55007,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+Cartmell Drive,Halton Moor,Leeds,,LS15,Lakeland Court Flats Cell LDS142   99925,Everything Everywhere Ltd&Hutchison 3G UK Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+Norman Towers (Telecom Appar),Spen Lane,Leeds,,LS16,Norman Towers LDS132 (Telecom Appar)   99448,Everything Everywhere Ltd&Hutchsion 3G Ltd,01 Aug 2009,31 Jul 2019,10,14730.08
+Clayton Court,Fillingfir Drive,,Leeds,LS18,Clayton Court LDS198   LS0056,Everything Everywhere Ltd & Hutchison 3G Ltd,01 Aug 2009,31 Jul 2019,10,15296.63
+Meynell Heights,,,,LS11,Meynell Heights- Wyk0184,Everything Everywhere Ltd & Hutchinson 3G UK,03 Aug 2009,02 Aug 2019,10,12750.00
+Larkhill Road,Lidgett Towers,Larkhill Road,Leeds,,Lidgett Towers - Site ref 27874,Everything Everywhere Ltd&Hutchison 3G UK Ltd,05 Jul 2010,04 Jul 2020,10,13000.00
+Marlborough Towers,Marlborough Towers,Park Lane,Leeds,,Marlborough Towers-Telecom App 7942vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Queenswood Drive - Telecom Site,Headingley,Leeds,LS6,,Queenswood Drive-Q'wood Ct building 19089o2,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Clayton Court,Fillingfir,,Leeds,,Clayton Court 11279vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Gledhow Towers - Telecom App,Brackenwood Drive,Leeds,,,Gledhow Towers - Telecom App (34909vf),Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Larkhill Road,Lidgett Towers,Larkhill Road,Leeds,,Lidgett Towers - Telecom App 3420vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Gipton Gate East,Oaktree Drive,,,,Gipton Gate East 23201vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+The Heights East,Armley,Leeds,,LS12,The Heights East- 4797o2,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Burnsall Gardens,Theaker Lane,,,,Burnsall Gardens - Cell No 23144vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,17000.00
+Poplar Mount,Armley,,,LS13,Poplar Mount Telecom Site 34884vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Barncroft Court,Seacroft,Yeb Ref 10463,,LS14,Barncroft Court 34196o2,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Barncroft Grange,Boggart Hill Drive,Seacroft,Leeds,LS14,Barncroft Grange Site 10639vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,17000.00
+Bailey Lane,Baileys Lane,Leeds,,,"Baileys Towers, Bailey Lane Ref 33420o2",Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Sherburn Court,Mill Green,,Leeds,,Sherburn Court CSR 16878o2,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Cartmell Drive,Halton Moor,Leeds,,LS15,Lakeland Court Cell No 35649o2,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00
+Norman Towers (Telecom Appar),Spen Lane,Leeds,,LS16,Norman Towers (Telecom Appar) 1701o2,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,22500.00
+King Lane,Leafield Towers,Leeds,,LS16,Leafield Towers - Cell 5516vf,Cornerstone Telecommunications Infrastructure,31 Mar 2015,30 Mar 2030,15,15000.00


### PR DESCRIPTION
What is done?

Added functionality to get the rental total for the lease year provided

Why was it done?

To satisfy this requirement:

From the list of all mast data, create a new list of mast data with “Lease Years” = 25 years.

- Output the list to the console, including all data fields
- Output the total rent for all items in this list to the console

These changes should cover the full requirements and also the testing for it.