### PR TITLE
added functionality to get masts owned per tenant

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,19 +3,23 @@ import csv
 
 from modules.getRentalTotalWithLease import getRentalTotalWithLease
 from modules.getLowestRental import getLowestRental
+from modules.mastsOwnedPerTenant import mastsOwnedPerTenant
 
 if __name__ == '__main__':
     with open('dataset.csv', 'r', newline="") as csvfile:
         reader = list(csv.DictReader(csvfile))
 
     if reader is not None:
-        print("Enter Lease number to get rental total for it: ")
-        lease = input()
-        print("Rental total for lease of {lease}: ".format(lease=lease) + str(getRentalTotalWithLease(reader, int(lease))))
+        # print("Enter Lease number to get rental total for it: ")
+        # lease = input()
+        # print("Rental total for lease of {lease}: ".format(lease=lease) + str(getRentalTotalWithLease(reader, int(lease))))
         
-        print("Enter the number of lowest rentals to fetch: ")
-        count = input()
-        listOfRentals = getLowestRental(reader, int(count))
-        print("{count} lowest rentals: ".format(count=count))
-        for rental in listOfRentals:
-            print(rental)
+        # print("Enter the number of lowest rentals to fetch: ")
+        # count = input()
+        # listOfRentals = getLowestRental(reader, int(count))
+        # print("{count} lowest rentals: ".format(count=count))
+        # for rental in listOfRentals:
+        #     print(rental)
+        
+        print("Amount of Masts owned per tenant: ")
+        print(mastsOwnedPerTenant(reader))

--- a/modules/mastsOwnedPerTenant.py
+++ b/modules/mastsOwnedPerTenant.py
@@ -1,0 +1,23 @@
+from collections import defaultdict
+
+
+def mastsOwnedPerTenant(reader):
+
+    tenantOwned = defaultdict(int)
+
+    # if tenant doesn't exist create new one else add one to value
+    for row in reader:
+        if tenantOwned[row["Tenant Name"]] is not None:
+            if tenantOwned[row["Tenant Name"]] <= 0:
+                tenantOwned[row["Tenant Name"]] = 1
+            else:
+                tenantOwned[row["Tenant Name"]] += 1
+    finalTenantList = []
+    for key, val in tenantOwned.items():
+        if val <= 1:
+            finalTenantList.append("Tenant {k} owns {v} mast.\n"
+                                   .format(k=key, v=val))
+        else:
+            finalTenantList.append("Tenant {k} owns {v} masts.\n"
+                                   .format(k=key, v=val))
+    return "\n".join([str(x) for x in finalTenantList])


### PR DESCRIPTION
What is done?

Added functionality to get masts owned per tenant

Why was it done?

To satisfy this requirement:

Create a dictionary containing the tenant name and a count of masts for each tenant

- Output the dictionary to the console in a readable form

Missing tests:

Currently, there are no tests associated with this functionality, any input to run relevant tests would be helpful