### PR TITLE
Rentals for date range

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,10 @@
 import csv
-
+from datetime import datetime
 
 from modules.getRentalTotalWithLease import getRentalTotalWithLease
 from modules.getLowestRental import getLowestRental
 from modules.mastsOwnedPerTenant import mastsOwnedPerTenant
+from modules.rentalsForDateRange import rentalsForDateRange
 
 if __name__ == '__main__':
     with open('dataset.csv', 'r', newline="") as csvfile:
@@ -21,7 +22,22 @@ if __name__ == '__main__':
         # for rental in listOfRentals:
         #     print(rental)
         
-        print("Amount of Masts owned per tenant: ")
-        print(mastsOwnedPerTenant(reader))
+        # print("Amount of Masts owned per tenant: ")
+        # print(mastsOwnedPerTenant(reader))
+
+        print("Enter a Start Date for rentals within that range(Format: 01 Jan 1990): ")
+        startDate = input()
+        print("Enter a End Date for rentals within that range(Format: 01 Jan 1990): ")
+        endDate = input()
+        listOfDates = rentalsForDateRange(reader, startDate, endDate)
+
+        # Change date format to 01/01/1990
+        for date in listOfDates:
+            date["Lease Start Date"] = datetime.strftime(datetime.strptime(
+            date["Lease Start Date"], '%d %b %Y'), '%d/%m/%Y')
+
+            date["Lease End Date"] = datetime.strftime(datetime.strptime(
+            date["Lease End Date"], '%d %b %Y'), '%d/%m/%Y')
+        print(listOfDates)
 else:
     raise KeyError("Could not load the file or read as Dictionary")

--- a/modules/rentalsForDateRange.py
+++ b/modules/rentalsForDateRange.py
@@ -7,6 +7,17 @@ def rentalsForDateRange(reader, start, end):
     end: Specify the end date to limit the data returned.
 
     """
+    if isinstance(start, str) is False:
+        raise TypeError("Expecting a String value")
+    try:
+        datetime.strptime(start, '%d %b %Y')
+    except ValueError:
+        raise ValueError("Expecting date format: '01 Jan 1990' for Start date")
+    try:
+        datetime.strptime(end, '%d %b %Y')
+    except ValueError:
+        raise ValueError("Expecting date format: '01 Jan 1990' for End date")
+
     sortedList = sorted(reader, key=lambda row: datetime.strptime(
             (row['Lease Start Date']), '%d %b %Y')
         )

--- a/modules/rentalsForDateRange.py
+++ b/modules/rentalsForDateRange.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+
+def rentalsForDateRange(reader, start, end):
+    """
+    start: Specify the start date to limit the data returned.
+    end: Specify the end date to limit the data returned.
+
+    """
+    sortedList = sorted(reader, key=lambda row: datetime.strptime(
+            (row['Lease Start Date']), '%d %b %Y')
+        )
+    dateInRange = []
+
+    # Expecting '01 Jan 1990' format for date
+    for date in sortedList:
+        if datetime.strptime(date["Lease Start Date"], '%d %b %Y') >= \
+                datetime.strptime(start, '%d %b %Y') and \
+                datetime.strptime(date["Lease Start Date"], '%d %b %Y') <= \
+                datetime.strptime(end, '%d %b %Y'):
+
+            dateInRange.append(date)
+    return dateInRange

--- a/modules/test_rentalsForDateRange.py
+++ b/modules/test_rentalsForDateRange.py
@@ -1,0 +1,130 @@
+import unittest
+import csv
+from rentalsForDateRange import rentalsForDateRange
+
+
+class TestRentalsForDateRange(unittest.TestCase):
+
+    def setUp(self):
+        print("\ntestSetup")
+        with open('testDataset.csv', 'r', newline="") as csvfile:
+            self.reader = list(csv.DictReader(csvfile))
+
+    def test_RentalsForDateRange(self):
+        print("\ntestingFunc")
+
+        rentals = [{'Property Name': 'Potternewton Crescent',
+                    'Property Address [1]': 'Potternewton Est Playing Field',
+                    'Property  Address [2]': '',
+                    'Property Address [3]': '',
+                    'Property Address [4]': 'LS7',
+                    'Unit Name': 'Potternewton Est Playing Field',
+                    'Tenant Name': 'Arqiva Ltd',
+                    'Lease Start Date': '24 Jun 1999',
+                    'Lease End Date': '23 Jun 2019',
+                    'Lease Years': '20',
+                    'Current Rent': '6600.00'},
+                   {'Property Name': 'Seacroft Gate (Chase) - Block 2',
+                    'Property Address [1]': 'Telecomms Apparatus',
+                    'Property  Address [2]': 'Leeds',
+                    'Property Address [3]': '',
+                    'Property Address [4]': 'LS14',
+                    'Unit Name': 'Seacroft Gate (Chase) block 2-Telecom App.',
+                    'Tenant Name': 'Vodafone Ltd.',
+                    'Lease Start Date': '30 Jan 2004',
+                    'Lease End Date': '29 Jan 2029',
+                    'Lease Years': '25',
+                    'Current Rent': '12250.00'},
+                   {'Property Name': 'Queenswood Heights',
+                    'Property Address [1]': 'Queenswood Heights',
+                    'Property  Address [2]': 'Queenswood Gardens',
+                    'Property Address [3]': 'Headingley',
+                    'Property Address [4]': 'Leeds',
+                    'Unit Name': 'Queenswood Hgt-Telecom App.',
+                    'Tenant Name': 'Vodafone Ltd',
+                    'Lease Start Date': '08 Nov 2004',
+                    'Lease End Date': '07 Nov 2029',
+                    'Lease Years': '25',
+                    'Current Rent': '9500.00'},
+                   {'Property Name': 'Armley - Burnsall Grange',
+                    'Property Address [1]': 'Armley',
+                    'Property  Address [2]': 'LS13',
+                    'Property Address [3]': '',
+                    'Property Address [4]': '',
+                    'Unit Name': 'Burnsall Grange CSR 37865',
+                    'Tenant Name': 'O2 (UK) Ltd',
+                    'Lease Start Date': '26 Jul 2007',
+                    'Lease End Date': '25 Jul 2032',
+                    'Lease Years': '25',
+                    'Current Rent': '12000.00'},
+                   {'Property Name': 'Seacroft Gate (Chase) - Block 2',
+                    'Property Address [1]': 'Telecomms Apparatus',
+                    'Property  Address [2]': 'Leeds',
+                    'Property Address [3]': '',
+                    'Property Address [4]': 'LS14',
+                    'Unit Name': 'Seacroft Gate (Chase) - Block 2, WYK 0414',
+                    'Tenant Name': 
+                        'Hutchinson3G Uk Ltd&Everything Everywhere Ltd',
+                    'Lease Start Date': '21 Aug 2007',
+                    'Lease End Date': '20 Aug 2032',
+                    'Lease Years': '25',
+                    'Current Rent': '12750.00'}]
+
+        self.assertEqual(
+            rentalsForDateRange(
+                self.reader, '01 Jun 1999', '31 Aug 2007'), rentals)
+
+        rentals = [{'Property Name': 'Seacroft Gate (Chase) - Block 2',
+                    'Property Address [1]': 'Telecomms Apparatus',
+                    'Property  Address [2]': 'Leeds',
+                    'Property Address [3]': '',
+                    'Property Address [4]': 'LS14',
+                    'Unit Name': 'Seacroft Gate (Chase) block 2-Telecom App.',
+                    'Tenant Name': 'Vodafone Ltd.',
+                    'Lease Start Date': '30 Jan 2004',
+                    'Lease End Date': '29 Jan 2029',
+                    'Lease Years': '25',
+                    'Current Rent': '12250.00'},
+                   {'Property Name': 'Queenswood Heights',
+                    'Property Address [1]': 'Queenswood Heights',
+                    'Property  Address [2]': 'Queenswood Gardens',
+                    'Property Address [3]': 'Headingley',
+                    'Property Address [4]': 'Leeds',
+                    'Unit Name': 'Queenswood Hgt-Telecom App.',
+                    'Tenant Name': 'Vodafone Ltd',
+                    'Lease Start Date': '08 Nov 2004',
+                    'Lease End Date': '07 Nov 2029',
+                    'Lease Years': '25',
+                    'Current Rent': '9500.00'},
+                   {'Property Name': 'Armley - Burnsall Grange',
+                    'Property Address [1]': 'Armley',
+                    'Property  Address [2]': 'LS13',
+                    'Property Address [3]': '',
+                    'Property Address [4]': '',
+                    'Unit Name': 'Burnsall Grange CSR 37865',
+                    'Tenant Name': 'O2 (UK) Ltd',
+                    'Lease Start Date': '26 Jul 2007',
+                    'Lease End Date': '25 Jul 2032',
+                    'Lease Years': '25',
+                    'Current Rent': '12000.00'},
+                   {'Property Name': 'Seacroft Gate (Chase) - Block 2',
+                    'Property Address [1]': 'Telecomms Apparatus',
+                    'Property Address [3]': '',
+                    'Property  Address [2]': 'Leeds',
+                    'Property Address [4]': 'LS14',
+                    'Unit Name': 
+                        'Seacroft Gate (Chase) - Block 2, WYK 0414',
+                    'Tenant Name': 
+                        'Hutchinson3G Uk Ltd&Everything Everywhere Ltd',
+                    'Lease Start Date': '21 Aug 2007',
+                    'Lease End Date': '20 Aug 2032',
+                    'Lease Years': '25',
+                    'Current Rent': '12750.00'}]
+
+        self.assertEqual(
+            rentalsForDateRange(
+                self.reader, '01 Jun 2003', '31 Aug 2007'), rentals)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/modules/test_rentalsForDateRange.py
+++ b/modules/test_rentalsForDateRange.py
@@ -10,9 +10,7 @@ class TestRentalsForDateRange(unittest.TestCase):
         with open('testDataset.csv', 'r', newline="") as csvfile:
             self.reader = list(csv.DictReader(csvfile))
 
-    def test_RentalsForDateRange(self):
-        print("\ntestingFunc")
-
+    def test_equalRentalsForDateRange(self):
         rentals = [{'Property Name': 'Potternewton Crescent',
                     'Property Address [1]': 'Potternewton Est Playing Field',
                     'Property  Address [2]': '',
@@ -124,6 +122,14 @@ class TestRentalsForDateRange(unittest.TestCase):
         self.assertEqual(
             rentalsForDateRange(
                 self.reader, '01 Jun 2003', '31 Aug 2007'), rentals)
+
+    def test_typeErrRentalsForDateRange(self):
+        with self.assertRaises(TypeError):
+            rentalsForDateRange(self.reader, 73, 'one')
+    
+    def test_valErrRentalsForDateRange(self):
+        with self.assertRaises(ValueError):
+            rentalsForDateRange(self.reader, '73', 'one')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
What is done?

Added functionality to get the rentals for the provided date range

Why was it done?

To satisfy this requirement:

List the data for rentals with “Lease Start Date” between 1st June 1999 and 31st August 2007

- Output the data to the console with dates formatted as DD/MM/YYYY

These changes should cover the full requirements and also the testing for it.